### PR TITLE
Make the scan visibility duration configurable

### DIFF
--- a/src/main/java/li/cil/scannable/client/ScanManager.java
+++ b/src/main/java/li/cil/scannable/client/ScanManager.java
@@ -184,7 +184,7 @@ public enum ScanManager {
             return;
         }
 
-        if (Constants.SCAN_STAY_DURATION < (int) (System.currentTimeMillis() - currentStart)) {
+        if (Settings.scanStayDuration < (int) (System.currentTimeMillis() - currentStart)) {
             pendingResults.forEach((provider, results) -> results.forEach(ScanResult::close));
             pendingResults.clear();
             synchronized (renderingResults) {

--- a/src/main/java/li/cil/scannable/common/config/Constants.java
+++ b/src/main/java/li/cil/scannable/common/config/Constants.java
@@ -33,6 +33,7 @@ public final class Constants {
     public static final String CONFIG_ENERGY_MODULE_FLUID = "config.scannable.energyCostModuleFluid";
     public static final String CONFIG_ENERGY_MODULE_ENTITY = "config.scannable.energyCostModuleEntity";
     public static final String CONFIG_BASE_SCAN_RADIUS = "config.scannable.baseScanRadius";
+    public static final String CONFIG_SCAN_STAY_DURATION = "config.scannable.scanStayDuration";
     public static final String CONFIG_IGNORED_BLOCKS = "config.scannable.ignoredBlocks";
     public static final String CONFIG_IGNORED_BLOCK_TAGS = "config.scannable.ignoredBlockTags";
     public static final String CONFIG_ORE_COMMON_BLOCKS = "config.scannable.oreCommonBlocks";
@@ -101,8 +102,6 @@ public final class Constants {
     public static final int SCAN_TIME_OFFSET = 200;
     // How long the ping takes to reach the end of the visible area.
     public static final int SCAN_GROWTH_DURATION = 2000;
-    // How long the results from a scan should remain visible.
-    public static final int SCAN_STAY_DURATION = 10000;
 
     // Reference render distance the above constants are relative to.
     public static final int REFERENCE_RENDER_DISTANCE = 12;

--- a/src/main/java/li/cil/scannable/common/config/Settings.java
+++ b/src/main/java/li/cil/scannable/common/config/Settings.java
@@ -52,6 +52,7 @@ public final class Settings {
     public static int energyCostModuleEntity = 75;
 
     public static int baseScanRadius = 64;
+    public static int scanStayDuration = 10000;
 
     public static Set<Block> ignoredBlocks = Util.make(new HashSet<>(), c -> {
         c.add(Blocks.COMMAND_BLOCK);
@@ -170,6 +171,7 @@ public final class Settings {
             energyCostModuleEntity = SERVER_INSTANCE.energyCostModuleEntity.get();
 
             baseScanRadius = SERVER_INSTANCE.baseScanRadius.get();
+            scanStayDuration = SERVER_INSTANCE.scanStayDuration.get();
 
             ignoredBlocks = deserializeSet(SERVER_INSTANCE.ignoredBlocks.get(), Settings::getBlock);
             ignoredBlockTags = deserializeSet(SERVER_INSTANCE.ignoredBlockTags.get(), Settings::getBlockTag);
@@ -207,6 +209,7 @@ public final class Settings {
         public ForgeConfigSpec.IntValue energyCostModuleEntity;
 
         public ForgeConfigSpec.IntValue baseScanRadius;
+        public ForgeConfigSpec.IntValue scanStayDuration;
 
         public ForgeConfigSpec.ConfigValue<List<? extends String>> ignoredBlocks;
         public ForgeConfigSpec.ConfigValue<List<? extends String>> ignoredBlockTags;
@@ -303,6 +306,12 @@ public final class Settings {
                             "Range modules will boost the range by half this value.")
                     .worldRestart()
                     .defineInRange("baseScanRadius", Settings.baseScanRadius, 16, 128);
+
+            scanStayDuration = builder
+                    .translation(Constants.CONFIG_SCAN_STAY_DURATION)
+                    .comment("How long the results from a scan should remain visible, in milliseconds.")
+                    .worldRestart()
+                    .defineInRange("scanStayDuration", Settings.scanStayDuration, 1000, 60000 * 5);
 
             builder.pop();
 

--- a/src/main/resources/assets/scannable/lang/en_us.json
+++ b/src/main/resources/assets/scannable/lang/en_us.json
@@ -58,6 +58,7 @@
   "config.scannable.energyCostModuleFluid": "Energy Cost: Fluid Module",
   "config.scannable.energyCostModuleEntity": "Energy Cost: Living Entity Module",
   "config.scannable.baseScanRadius": "Base Scan Radius",
+  "config.scannable.scanStayDuration": "Scan Stay Duration",
   "config.scannable.ignoredBlocks": "Ignored Blocks",
   "config.scannable.ignoredBlockTags": "Ignored Block Tags",
   "config.scannable.oreCommonBlocks": "Common Ore: Blocks",


### PR DESCRIPTION
Ten seconds of result visibility kept feeling annoyingly a bit too short, for both myself and others on my server, so I've made it configurable.

Note: I only provided an English localisation entry for the new configuration item, as I sadly don't speak anything else.